### PR TITLE
Update swagger-spec.json version 2

### DIFF
--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -20,8 +20,6 @@
         "description": "Create a new entry for a set of uploaded files and associated configs to launch a new mine. This can allocate an id which all file uploads will be associated with.",
         "operationId": "setMineConfig",
         "requestBody": {
-          "required": false,
-          "description": "Config to set for Mine",
           "content": {
             "application/json": {
               "schema": {
@@ -32,8 +30,9 @@
               "schema": {
                 "$ref": "#/components/schemas/MineConfig"
               }
-            }
-          }
+            }, 
+          "required": false,
+          "description": "Config to set for Mine"
         },
         "responses": {
           "200": {
@@ -93,7 +92,6 @@
         }
       }
     },
-
     "/file/properties/detect": {
       "post": {
         "summary": "Return identified file type",
@@ -255,9 +253,9 @@
             "description": "ID of mineconfig to fetch tools for",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
+              "type": "string",
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-556642440000"
             }
           }
         ]
@@ -290,9 +288,9 @@
             "description": "ID of mineconfig to set tools for",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
+              "type": "string",
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-556642440000"
             }
           }
         ]
@@ -407,9 +405,6 @@
     "schemas": {
       "MineConfig": {
         "type": "object",
-        "required": [
-          "id"
-        ],
         "properties": {
           "mineName": {
             "type": "string",
@@ -426,11 +421,6 @@
           "licence": {
             "type": "string",
             "example": "CC0"
-          },
-          "date-updated": {
-            "type": "string",
-            "format": "date",
-            "example": "2018-01-22T17:32:28Z"
           }
         },
         "xml": {
@@ -442,6 +432,7 @@
         "required": [
           "name",
           "fileContents",
+          "fileType",
           "organism"
         ],
         "properties": {
@@ -451,6 +442,16 @@
           },
           "fileContents": {
             "type": "string"
+          },
+          "fileType": {
+            "type": "string",
+            "enum": [
+              "fasta",
+              "gff",
+              "tab",
+              "csv"
+            ],
+            "example": "fasta"
           },
           "organism": {
             "allOf": [

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -40,14 +40,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "integer",
-                  "example": 98564512
+                  "type": "string",
+                  "example": "123e4567-e89b-12d3-a456-556642440000"
                 }
               },
               "application/xml": {
                 "schema": {
-                  "type": "integer",
-                  "example": 98564512
+                  "type": "string",
+                  "example": "123e4567-e89b-12d3-a456-556642440000"
                 }
               }
             }
@@ -58,7 +58,7 @@
     "/mine/config/{mineId}": {
       "get": {
         "summary": "Get mine config",
-        "description": "return configured details (if any) for a given mineconfig id",
+        "description": "return configured details (if any) for a given mine id",
         "operationId": "getMineConfig",
         "parameters": [
           {
@@ -67,9 +67,9 @@
             "description": "ID of mineconfig to fetch",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
+              "type": "string",
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-556642440000"
             }
           }
         ],
@@ -92,119 +92,7 @@
         }
       }
     },
-    "/mine/nameAvailability": {
-      "post": {
-        "summary": "Check if a given username+minename combo is taken",
-        "operationId": "checkNameAvailability",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MineName"
-              }
-            },
-            "application/xml": {
-              "schema": {
-                "$ref": "#/components/schemas/MineName"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NameAvailability"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/NameAvailability"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/mine/dataTools/{mineId}": {
-      "get": {
-        "summary": "Retrieve set of tools suitable for the given mine",
-        "responses": {
-          "200": {
-            "description": "success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DataTool"
-                  }
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DataTool"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "mineId",
-            "in": "path",
-            "description": "ID of mineconfig to fetch tools for",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
-            }
-          }
-        ]
-      }
-    },
-    "/mine/dataTool/{mineId}": {
-      "post": {
-        "summary": "Set tools to be used for the given mine",
-        "responses": {
-          "200": {
-            "description": "success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataToolResponse"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataToolResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "mineId",
-            "in": "path",
-            "description": "ID of mineconfig to set tools for",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
-            }
-          }
-        ]
-      }
-    },
+
     "/file/properties/detect": {
       "post": {
         "summary": "Return identified file type",
@@ -331,6 +219,82 @@
           },
           "required": true
         }
+      }
+    },
+    "/mine/dataTools/{mineId}": {
+      "get": {
+        "summary": "Retrieve set of tools suitable for the given mine",
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTool"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTool"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "mineId",
+            "in": "path",
+            "description": "ID of mineconfig to fetch tools for",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "example": 98564512
+            }
+          }
+        ]
+      }
+    },
+    "/mine/dataTool/{mineId}": {
+      "post": {
+        "summary": "Set tools to be used for the given mine",
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataToolResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataToolResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "mineId",
+            "in": "path",
+            "description": "ID of mineconfig to set tools for",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "example": 98564512
+            }
+          }
+        ]
       }
     },
     "/build/trigger": {
@@ -592,7 +556,7 @@
             "type": "integer"
           },
           "mineID": {
-            "type": "integer"
+            "type": "string"
           }
         },
         "xml": {
@@ -605,14 +569,6 @@
           "taxonID"
         ],
         "properties": {
-          "name": {
-            "type": "string",
-            "example": "H. Sapiens"
-          },
-          "genomeBuild": {
-            "type": "string",
-            "example": "GRCh38.p7"
-          },
           "taxonID": {
             "type": "integer",
             "example": "9606"
@@ -660,7 +616,7 @@
               "type": "integer"
             },
             "mineID": {
-              "type": "integer"
+              "type": "string"
             }
           },
           "xml": {
@@ -678,55 +634,9 @@
             "type": "string",
             "example": "alice@mylab.com"
           },
-          "username": {
-            "type": "string",
-            "example": "alice"
-          },
           "password": {
             "type": "string",
             "format": "password"
-          }
-        }
-      },
-      "Lab": {
-        "type": "object",
-        "required": [
-          "subdomain",
-          "users"
-        ],
-        "properties": {
-          "subdomain": {
-            "type": "string",
-            "example": "AliceLab"
-          },
-          "mines": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MineConfig"
-            }
-          },
-          "users": {
-            "type": "object",
-            "properties": {
-              "Owners": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              },
-              "Admins": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              },
-              "Viewers": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
           }
         }
       },
@@ -740,26 +650,13 @@
             "type": "string",
             "example": "MyFirstMine"
           },
-          "lab": {
-            "type": "object",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Lab"
-              }
-            ]
-          },
-          "mineUrl": {
-            "type": "string",
-            "example": "myfirstmine.alicelab.intermine.org"
-          },
           "privacy": {
             "type": "string",
             "enum": [
-              "private",
               "unlisted",
               "public"
             ],
-            "example": "private"
+            "example": "unlisted"
           },
           "licence": {
             "type": "string",
@@ -773,27 +670,22 @@
       "SupplementaryDataSource": {
         "type": "object",
         "required": [
-          "humanName",
-          "modelName",
+          "label",
           "description",
           "url"
         ],
         "properties": {
-          "humanName": {
+          "label": {
             "type": "string",
-            "example": "GO annotations"
-          },
-          "modelName": {
-            "type": "string",
-            "example": "GOAnnotations"
+            "example": "NCBI Taxon ID information"
           },
           "description": {
             "type": "string",
-            "example": "A GO annotation is a statement about the function of a particular gene."
+            "example": "Will populate empty fields for Organism, e.g. name (Based on NCBI taxon ID)"
           },
           "url": {
             "type": "string",
-            "example": "http://geneontology.org/page/go-annotations"
+            "example": "https://intermine.readthedocs.io/en/latest/database/data-sources/library/organism/"
           }
         },
         "xml": {
@@ -808,32 +700,6 @@
         "example": [
           "GOAnnotations",
           "PubMed"
-        ]
-      },
-      "MineName": {
-        "type": "object",
-        "required": [
-          "labName",
-          "mineName"
-        ],
-        "properties": {
-          "mineName": {
-            "type": "string",
-            "example": "myFirstDatabase"
-          },
-          "userName": {
-            "type": "string",
-            "example": "AliceLab"
-          }
-        }
-      },
-      "NameAvailability": {
-        "type": "string",
-        "enum": [
-          "lab_taken",
-          "minename_taken",
-          "both_taken",
-          "free"
         ]
       },
       "DataBuild": {

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -20,6 +20,7 @@
         "description": "Create a new entry for a set of uploaded files and associated configs to launch a new mine. This can allocate an id which all file uploads will be associated with.",
         "operationId": "setMineConfig",
         "requestBody": {
+          "required": false,
           "description": "Config to set for Mine",
           "content": {
             "application/json": {
@@ -40,14 +41,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "integer",
-                  "example": 98564512
+                  "type": "string",
+                  "example": "123e4567-e89b-12d3-a456-556642440000"
                 }
               },
               "application/xml": {
                 "schema": {
-                  "type": "integer",
-                  "example": 98564512
+                  "type": "string",
+                  "example": "123e4567-e89b-12d3-a456-556642440000"
                 }
               }
             }
@@ -58,7 +59,7 @@
     "/mine/config/{mineId}": {
       "get": {
         "summary": "Get mine config",
-        "description": "return configured details (if any) for a given mineconfig id",
+        "description": "return configured details (if any) for a given mine id.",
         "operationId": "getMineConfig",
         "parameters": [
           {
@@ -67,9 +68,9 @@
             "description": "ID of mineconfig to fetch",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
+              "type": "string",
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-556642440000"
             }
           }
         ],
@@ -92,119 +93,7 @@
         }
       }
     },
-    "/mine/nameAvailability": {
-      "post": {
-        "summary": "Check if a given username+minename combo is taken",
-        "operationId": "checkNameAvailability",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MineName"
-              }
-            },
-            "application/xml": {
-              "schema": {
-                "$ref": "#/components/schemas/MineName"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NameAvailability"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/NameAvailability"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/mine/dataTools/{mineId}": {
-      "get": {
-        "summary": "Retrieve set of tools suitable for the given mine",
-        "responses": {
-          "200": {
-            "description": "success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DataTool"
-                  }
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DataTool"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "mineId",
-            "in": "path",
-            "description": "ID of mineconfig to fetch tools for",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
-            }
-          }
-        ]
-      }
-    },
-    "/mine/dataTool/{mineId}": {
-      "post": {
-        "summary": "Set tools to be used for the given mine",
-        "responses": {
-          "200": {
-            "description": "success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataToolResponse"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/DataToolResponse"
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "mineId",
-            "in": "path",
-            "description": "ID of mineconfig to set tools for",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "example": 98564512
-            }
-          }
-        ]
-      }
-    },
+
     "/file/properties/detect": {
       "post": {
         "summary": "Return identified file type",
@@ -333,6 +222,82 @@
         }
       }
     },
+    "/mine/dataTools/{mineId}": {
+      "get": {
+        "summary": "Retrieve set of tools suitable for the given mine",
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTool"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DataTool"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "mineId",
+            "in": "path",
+            "description": "ID of mineconfig to fetch tools for",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "example": 98564512
+            }
+          }
+        ]
+      }
+    },
+    "/mine/dataTool/{mineId}": {
+      "post": {
+        "summary": "Set tools to be used for the given mine",
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataToolResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataToolResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "mineId",
+            "in": "path",
+            "description": "ID of mineconfig to set tools for",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "example": 98564512
+            }
+          }
+        ]
+      }
+    },
     "/build/trigger": {
       "post": {
         "summary": "Begin build of specified mine",
@@ -440,6 +405,38 @@
   ],
   "components": {
     "schemas": {
+      "MineConfig": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "mineName": {
+            "type": "string",
+            "example": "MyFirstMine"
+          },
+          "privacy": {
+            "type": "string",
+            "enum": [
+              "unlisted",
+              "public"
+            ],
+            "example": "unlisted"
+          },
+          "licence": {
+            "type": "string",
+            "example": "CC0"
+          },
+          "date-updated": {
+            "type": "string",
+            "format": "date",
+            "example": "2018-01-22T17:32:28Z"
+          }
+        },
+        "xml": {
+          "name": "MineConfig"
+        }
+      },
       "DataFile": {
         "type": "object",
         "required": [
@@ -592,7 +589,7 @@
             "type": "integer"
           },
           "mineID": {
-            "type": "integer"
+            "type": "string"
           }
         },
         "xml": {
@@ -607,11 +604,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "example": "H. Sapiens"
-          },
-          "genomeBuild": {
-            "type": "string",
-            "example": "GRCh38.p7"
+            "example": "Homo sapiens"
           },
           "taxonID": {
             "type": "integer",
@@ -660,7 +653,7 @@
               "type": "integer"
             },
             "mineID": {
-              "type": "integer"
+              "type": "string"
             }
           },
           "xml": {
@@ -678,122 +671,32 @@
             "type": "string",
             "example": "alice@mylab.com"
           },
-          "username": {
-            "type": "string",
-            "example": "alice"
-          },
           "password": {
             "type": "string",
             "format": "password"
           }
         }
       },
-      "Lab": {
-        "type": "object",
-        "required": [
-          "subdomain",
-          "users"
-        ],
-        "properties": {
-          "subdomain": {
-            "type": "string",
-            "example": "AliceLab"
-          },
-          "mines": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MineConfig"
-            }
-          },
-          "users": {
-            "type": "object",
-            "properties": {
-              "Owners": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              },
-              "Admins": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              },
-              "Viewers": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
-          }
-        }
-      },
-      "MineConfig": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "mineName": {
-            "type": "string",
-            "example": "MyFirstMine"
-          },
-          "lab": {
-            "type": "object",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Lab"
-              }
-            ]
-          },
-          "mineUrl": {
-            "type": "string",
-            "example": "myfirstmine.alicelab.intermine.org"
-          },
-          "privacy": {
-            "type": "string",
-            "enum": [
-              "private",
-              "unlisted",
-              "public"
-            ],
-            "example": "private"
-          },
-          "licence": {
-            "type": "string",
-            "example": "CC0"
-          }
-        },
-        "xml": {
-          "name": "MineConfig"
-        }
-      },
+
       "SupplementaryDataSource": {
         "type": "object",
         "required": [
-          "humanName",
-          "modelName",
+          "label",
           "description",
           "url"
         ],
         "properties": {
-          "humanName": {
+          "label": {
             "type": "string",
-            "example": "GO annotations"
-          },
-          "modelName": {
-            "type": "string",
-            "example": "GOAnnotations"
+            "example": "NCBI Taxon ID information"
           },
           "description": {
             "type": "string",
-            "example": "A GO annotation is a statement about the function of a particular gene."
+            "example": "Will populate empty fields for Organism, e.g. name (Based on NCBI taxon ID)"
           },
           "url": {
             "type": "string",
-            "example": "http://geneontology.org/page/go-annotations"
+            "example": "https://intermine.readthedocs.io/en/latest/database/data-sources/library/organism/"
           }
         },
         "xml": {
@@ -808,32 +711,6 @@
         "example": [
           "GOAnnotations",
           "PubMed"
-        ]
-      },
-      "MineName": {
-        "type": "object",
-        "required": [
-          "labName",
-          "mineName"
-        ],
-        "properties": {
-          "mineName": {
-            "type": "string",
-            "example": "myFirstDatabase"
-          },
-          "userName": {
-            "type": "string",
-            "example": "AliceLab"
-          }
-        }
-      },
-      "NameAvailability": {
-        "type": "string",
-        "enum": [
-          "lab_taken",
-          "minename_taken",
-          "both_taken",
-          "free"
         ]
       },
       "DataBuild": {

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -677,33 +677,6 @@
           }
         }
       },
-      "MineConfig": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "mineName": {
-            "type": "string",
-            "example": "MyFirstMine"
-          },
-          "privacy": {
-            "type": "string",
-            "enum": [
-              "unlisted",
-              "public"
-            ],
-            "example": "unlisted"
-          },
-          "licence": {
-            "type": "string",
-            "example": "CC0"
-          }
-        },
-        "xml": {
-          "name": "MineConfig"
-        }
-      },
       "SupplementaryDataSource": {
         "type": "object",
         "required": [

--- a/swagger-spec.json
+++ b/swagger-spec.json
@@ -20,6 +20,8 @@
         "description": "Create a new entry for a set of uploaded files and associated configs to launch a new mine. This can allocate an id which all file uploads will be associated with.",
         "operationId": "setMineConfig",
         "requestBody": {
+          "required": false,
+          "description": "Config to set for Mine",
           "content": {
             "application/json": {
               "schema": {
@@ -30,9 +32,8 @@
               "schema": {
                 "$ref": "#/components/schemas/MineConfig"
               }
-            }, 
-          "required": false,
-          "description": "Config to set for Mine"
+            }
+          }
         },
         "responses": {
           "200": {
@@ -92,6 +93,7 @@
         }
       }
     },
+
     "/file/properties/detect": {
       "post": {
         "summary": "Return identified file type",
@@ -405,6 +407,9 @@
     "schemas": {
       "MineConfig": {
         "type": "object",
+        "required": [
+          "id"
+        ],
         "properties": {
           "mineName": {
             "type": "string",
@@ -432,7 +437,7 @@
         "required": [
           "name",
           "fileContents",
-          "fileType",
+          "fileFormat",
           "organism"
         ],
         "properties": {
@@ -443,7 +448,7 @@
           "fileContents": {
             "type": "string"
           },
-          "fileType": {
+          "fileFormat": {
             "type": "string",
             "enum": [
               "fasta",


### PR DESCRIPTION
1. Got rid of the idea of labs and "Private" mines. If we do have that idea, it will be in the authentication layer which will be elsewhere.
(I'd like the intermine generator tool to be able to write to disk whereever - locally or on AWS. If they did want a private mine, use the wizard to create their own mine and host it themselves. Don't know how feasible this is)
2. Mine ID is now a String instead of integer. UUIDs are not guessable and we don't have to keep track of which ID we are on if that app restarts. Java doesn't generate truely random integers. Does anyone? Is there such a thing in reality.
3. Removed name availability check. They are going to get a random IP address assigned by AWS and can name their mine whatever they want. We can add a proxy, however amazonians do, but that might be in version 2. 

All of this is up for discussion. I've only just got the end points returning dummy values, I haven't started yet really. Just a first pass!

Tell @sergiocontrino too.

Also the name for this file in is now `openapi.json` for OpenAPI v3